### PR TITLE
fix: correct registry_type field and bump to v1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reddit-mcp-buddy",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
@@ -1816,15 +1816,15 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.4"
+        "color-name": "~1.1.5"
       },
       "engines": {
         "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.5.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-buddy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Clean, LLM-optimized Reddit MCP server. Browse posts, search content, analyze users. No fluff, just Reddit data.",
   "main": "dist/index.js",
   "mcpName": "io.github.karanb192/reddit-mcp-buddy",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.karanb192/reddit-mcp-buddy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Reddit browser for AI assistants. Browse posts, search content, analyze users. No API keys needed.",
   "author": {
     "name": "Karan Bansal",
@@ -18,9 +18,9 @@
   },
   "packages": [
     {
-      "registryType": "npm",
+      "registry_type": "npm",
       "identifier": "reddit-mcp-buddy",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,7 +27,7 @@ import {
 
 // Server metadata
 export const SERVER_NAME = 'reddit-mcp-buddy';
-export const SERVER_VERSION = '1.1.4';
+export const SERVER_VERSION = '1.1.5';
 
 /**
  * Create MCP server with proper protocol implementation


### PR DESCRIPTION
- Fixed critical MCP Registry schema compliance issue
- Changed registryType (wrong camelCase) back to registry_type (correct snake_case)
- This was preventing v1.1.2, v1.1.3, and v1.1.4 from publishing to MCP Registry
- Bump version to 1.1.5 across all files

The MCP Registry schema explicitly requires 'registry_type' in snake_case format, not camelCase. This fix finally resolves all validation errors.