### PR TITLE
fix: correct color-name package version to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1816,15 +1816,15 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-name": "~1.1.5"
+        "color-name": "~1.1.4"
       },
       "engines": {
         "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.5.tgz",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
The v1.1.5 bump accidentally changed the color-name dependency from 1.1.4 to 1.1.5, but color-name doesn't have a 1.1.5 version. This was causing npm ci to fail with a 404 error.

Restored color-name to the correct 1.1.4 version.