### PR TITLE
feat: add GitHub Releases workflow for .mcpb distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release with Desktop Extension
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (v1.1.6, v1.1.6-test-1, etc.)
+
+permissions:
+  contents: write  # Required to create releases and upload assets
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Build Desktop Extension (.mcpb)
+        run: |
+          chmod +x scripts/build-mcpb.sh
+          ./scripts/build-mcpb.sh
+
+      - name: Verify .mcpb file was created
+        run: |
+          if [ ! -f "reddit-mcp-buddy.mcpb" ]; then
+            echo "Error: reddit-mcp-buddy.mcpb not found!"
+            exit 1
+          fi
+          ls -lh reddit-mcp-buddy.mcpb
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release ${{ steps.get_version.outputs.VERSION }}
+          draft: false
+          prerelease: ${{ contains(github.ref, '-test-') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          generate_release_notes: true
+          files: |
+            reddit-mcp-buddy.mcpb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release Summary
+        run: |
+          echo "✅ Release created successfully!"
+          echo "📦 Version: ${{ steps.get_version.outputs.VERSION }}"
+          echo "🔗 Download: https://github.com/${{ github.repository }}/releases/download/${{ steps.get_version.outputs.VERSION }}/reddit-mcp-buddy.mcpb"

--- a/README.md
+++ b/README.md
@@ -246,18 +246,22 @@ docker run -it karanb192/reddit-mcp-buddy
 
 ### Claude Desktop Extension
 
-For advanced users who want one-click installation in Claude Desktop, you can build the extension locally:
+For one-click installation in Claude Desktop, download the pre-built extension:
 
-1. **Build the extension** (requires cloning the repository):
+**📦 [Download reddit-mcp-buddy.mcpb](https://github.com/karanb192/reddit-mcp-buddy/releases/latest/download/reddit-mcp-buddy.mcpb)**
+
+Then:
+1. **Open the downloaded file** - Claude Desktop will automatically install the extension
+2. **Restart Claude Desktop** - The Reddit tools will be available
+
+#### Build from Source (Optional)
+
+If you prefer to build the extension yourself:
 ```bash
 git clone https://github.com/karanb192/reddit-mcp-buddy.git
 cd reddit-mcp-buddy
 ./scripts/build-mcpb.sh
 ```
-
-2. **Install in Claude Desktop**:
-   - Open the generated `reddit-mcp-buddy.mcpb` file
-   - Claude Desktop will automatically install the extension
 
 **Note**: The Desktop Extension format is currently in preview (September 2025). Most users should use the standard npm installation method shown in [Quick Start](#quick-start-30-seconds).
 


### PR DESCRIPTION
## Summary
- Adds automated GitHub Actions workflow for building and releasing .mcpb files
- Updates README with direct download link to latest release
- Solves the problem of distributing 6.2MB .mcpb files without bloating npm/Docker

## Changes
1. **New Workflow** (`.github/workflows/release.yml`):
   - Triggers on version tags (v*)
   - Builds project and .mcpb extension
   - Creates GitHub Release with .mcpb as downloadable asset
   - Supports test releases (v*-test-* tags are marked as prerelease)

2. **Updated README**:
   - Added prominent download link using `releases/latest/download/` URL
   - Link auto-updates to newest version (no manual updates needed)
   - Kept build-from-source option as alternative

3. **Verification**:
   - `.gitignore` already excludes `*.mcpb` files ✅

## Why This Approach?
- ✅ Zero git bloat (6.2MB every 2-3 weeks would add ~124MB/year)
- ✅ Standard GitHub practice for distributing binaries
- ✅ Download link auto-updates to latest version
- ✅ Users get easy one-click download
- ✅ Can be fully automated

## Testing Plan
After merge:
1. Create test tag: `git tag v1.1.6-test-1 && git push origin v1.1.6-test-1`
2. Watch GitHub Actions build the .mcpb file
3. Verify release is created with .mcpb attached
4. Test download link works
5. Iterate with test-2, test-3 as needed
6. Delete test releases before official v1.1.7

## Related
- Addresses the distribution strategy discussed for Desktop Extension
- Keeps npm package lean (only dist/, README, LICENSE)
- Keeps Docker image minimal