### PR TITLE
docs: prioritize Desktop Extension in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that en
 
 ## Quick Start (30 seconds)
 
-### For Claude Desktop
+### For Claude Desktop - Desktop Extension (Easiest!)
+
+1. **Download**: [reddit-mcp-buddy.mcpb](https://github.com/karanb192/reddit-mcp-buddy/releases/latest/download/reddit-mcp-buddy.mcpb)
+2. **Install**: Open the downloaded file
+3. **Done!** Reddit tools are now available in Claude
+
+### For Claude Desktop - NPM Method (Alternative)
 
 Add this to your `claude_desktop_config.json`:
 
@@ -60,7 +66,9 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
-That's it! Reddit MCP Buddy is now available in Claude.
+### For Other MCP Clients
+
+Use the NPM method: `npx reddit-mcp-buddy`
 
 ## What can it do?
 


### PR DESCRIPTION
## Summary
Restructures the Quick Start section to prioritize the Desktop Extension (.mcpb) installation method, which is significantly easier than editing JSON config files.

## Changes
- ✅ **Desktop Extension first**: Now the primary Quick Start method for Claude Desktop users
- ✅ **Clear labeling**: Marked as "Easiest!" to encourage adoption
- ✅ **3-step process**: Download → Install → Done (vs. editing JSON)
- ✅ **NPM as alternative**: Still available for users who prefer it
- ✅ **Other MCP clients**: Added section for non-Claude Desktop users

## Before
```markdown
### For Claude Desktop

Add this to your `claude_desktop_config.json`:
[JSON config...]
```

## After
```markdown
### For Claude Desktop - Desktop Extension (Easiest!)

1. Download: [link]
2. Install: Open the downloaded file
3. Done!

### For Claude Desktop - NPM Method (Alternative)
[JSON config...]

### For Other MCP Clients
Use: npx reddit-mcp-buddy
```

## Why?
The .mcpb method is:
- ✅ No file editing required
- ✅ No need to find config file location
- ✅ One-click installation
- ✅ Instant activation (no restart)

Users should see the easiest method first!

## Testing
- [x] Links work correctly
- [x] Markdown renders properly
- [x] All installation methods covered